### PR TITLE
Add "Switch notebook with return key" option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ ipm install switch-notebook
 
 Press `cmd+p` to activate.
 
+### Option
+
+By enabling "Switch notebook with return key" in the plugin settings, you can switch between notebooks using the arrow keys on the keyboard and the return key.
+
 ### Changelog
 
+- 0.1.1 - Add "Switch notebook with return key" option.
 - 0.1.0 - First release

--- a/lib/switch-notebook-message-dialog.js
+++ b/lib/switch-notebook-message-dialog.js
@@ -1,14 +1,13 @@
-'use babel';
+"use babel";
 
-import React from 'react';
-import { CompositeDisposable } from 'event-kit';
-import { Dropdown } from 'semantic-ui-react';
+import React from "react";
+import { CompositeDisposable } from "event-kit";
+import { Dropdown } from "semantic-ui-react";
 
 export default class SwitchNotebookMessageDialog extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { books: [] };
-
+    this.state = { options: [], bookId: "" };
     inkdrop.onAppReady(() => {
       const { books } = inkdrop.store.getState();
       const options = books.all.map(({ _id, name }) => ({
@@ -27,8 +26,8 @@ export default class SwitchNotebookMessageDialog extends React.Component {
     // Register command that toggles this dialog
     this.subscriptions.add(
       inkdrop.commands.add(document.body, {
-        'switch-notebook:toggle': () => this.toggle(),
-      }),
+        "switch-notebook:toggle": () => this.toggle(),
+      })
     );
   }
 
@@ -36,11 +35,38 @@ export default class SwitchNotebookMessageDialog extends React.Component {
     this.subscriptions.dispose();
   }
 
-  handleSwitch = (event, data) => {
-    inkdrop.commands.dispatch(document.body, 'core:note-list-show-notes-in-book', {
-      bookId: data.value,
-    });
+  switchNotebook(bookId) {
+    inkdrop.commands.dispatch(
+      document.body,
+      "core:note-list-show-notes-in-book",
+      {
+        bookId: bookId,
+      }
+    );
+    inkdrop.commands.dispatch(document.body, "core:focus-note-list-bar");
     this.refs.dialog.dismissDialog();
+  }
+
+  handleSwitch = (event, data) => {
+    const switchWithReturnKey = inkdrop.config.get(
+      "switch-notebook.switchWithReturnKey"
+    );
+
+    if (switchWithReturnKey) {
+      this.setState({ bookId: data.value });
+    } else {
+      this.switchNotebook(data.value);
+    }
+  };
+
+  handleKeyUp = (event) => {
+    const switchWithReturnKey = inkdrop.config.get(
+      "switch-notebook.switchWithReturnKey"
+    );
+
+    if (switchWithReturnKey && event.keyCode === 13) {
+      this.switchNotebook(this.state.bookId);
+    }
   };
 
   toggle() {
@@ -62,6 +88,7 @@ export default class SwitchNotebookMessageDialog extends React.Component {
         modalSettings={{ autofocus: true }}
       >
         <Dropdown
+          onKeyUp={this.handleKeyUp}
           options={this.state.options}
           placeholder="Select notebook"
           onChange={this.handleSwitch}

--- a/lib/switch-notebook.js
+++ b/lib/switch-notebook.js
@@ -3,6 +3,14 @@
 import SwitchNotebookMessageDialog from './switch-notebook-message-dialog';
 
 module.exports = {
+  config: {
+    switchWithReturnKey: {
+      title: 'Switch notebook with return key',
+      type: 'boolean',
+      default: false
+    },
+  },
+
   activate() {
     inkdrop.components.registerClass(SwitchNotebookMessageDialog);
     inkdrop.layouts.addComponentToLayout('modal', 'SwitchNotebookMessageDialog');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "switch-notebook",
   "main": "./lib/switch-notebook",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Quickly switch between notebooks",
   "keywords": [],
   "repository": "https://github.com/marconi/switch-notebook",


### PR DESCRIPTION
Hi  @marconi ,  Thank you for the great plugin.

I wanted to switch between the keyboard and the notebook with the return key, so I added an option for that.
If you like it, I hope you'll merge and release it.